### PR TITLE
Add dontExtendString

### DIFF
--- a/src/string-format.coffee
+++ b/src/string-format.coffee
@@ -37,6 +37,11 @@ resolve = (object, key) ->
   value = object[key]
   if typeof value is 'function' then value.call object else value
 
+oldStringFormat = String::format
+
+format.dontExtendString = ->
+  String::format = oldStringFormat
+  return format
 
 String::format = (args...) -> format this, args...
 


### PR DESCRIPTION
The side effect of prototype extension makes it harder to use this module in other modules (as a dependency).

This patch adds `dontExtendString` method that can be used by client module in this way:

``` js
var format = require('string-format').dontExtendString();
/* .. */
```
