### PR TITLE
extend String.prototype only if requested

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@
             DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
                     Version 2, December 2004
 
- Copyright (c) 2012..2014 David Chambers <dc@davidchambers.me>
+ Copyright (c) 2012..2015 David Chambers <dc@davidchambers.me>
 
  Everyone is permitted to copy and distribute verbatim or modified
  copies of this license document, and changing it is allowed as long

--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,4 @@ setup:
 .PHONY: test
 test: all
 	$(MOCHA)
+	$(COFFEE) test/readme.coffee

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "devDependencies": {
     "coffee-script": "1.8.x",
-    "mocha": "1.13.x",
+    "mocha": "2.x.x",
+    "ramda": "0.8.x",
     "xyz": "0.5.x"
   }
 }

--- a/src/string-format.coffee
+++ b/src/string-format.coffee
@@ -3,7 +3,10 @@ class ValueError extends Error
   name: 'ValueError'
 
 
-format = (template, args...) ->
+implicitToExplicit = 'cannot switch from implicit to explicit numbering'
+explicitToImplicit = 'cannot switch from explicit to implicit numbering'
+
+create = (transformers = {}) -> (template, args...) ->
 
   idx = 0
   explicit = implicit = no
@@ -15,18 +18,19 @@ format = (template, args...) ->
     return literal if literal
 
     if key.length
+      throw new ValueError implicitToExplicit if implicit
       explicit = yes
-      throw new ValueError message.format('implicit', 'explicit') if implicit
       value = lookup(args, key) ? ''
     else
+      throw new ValueError explicitToImplicit if explicit
       implicit = yes
-      throw new ValueError message.format('explicit', 'implicit') if explicit
       value = args[idx++] ? ''
 
-    if Object::hasOwnProperty.call format.transformers, transformer
-      format.transformers[transformer] value
+    if Object::hasOwnProperty.call transformers, transformer
+      transformers[transformer] value
     else
       value
+
 
 lookup = (object, key) ->
   unless /^(\d+)([.]|$)/.test key
@@ -36,14 +40,25 @@ lookup = (object, key) ->
     key = match[2]
   resolve object, key
 
+
 resolve = (object, key) ->
   value = object[key]
   if typeof value is 'function' then value.call object else value
 
 
-String::format = (args...) -> format this, args...
+# format :: String,*... -> String
+format = create {}
 
-String::format.transformers = format.transformers = {}
+# format.create :: Object? -> String,*... -> String
+format.create = create
+
+# format.extend :: Object,Object? -> ()
+format.extend = (prototype, transformers) ->
+  $format = create transformers
+  prototype.format = -> $format this, arguments...
+  return
 
 
-module?.exports = format
+if typeof module isnt 'undefined' then module.exports = format
+else if typeof define is 'function' and define.amd then define format
+else window.format = format

--- a/test/readme.coffee
+++ b/test/readme.coffee
@@ -1,0 +1,64 @@
+fs = require 'fs'
+path = require 'path'
+vm = require 'vm'
+
+R = require 'ramda'
+
+format = require '..'
+
+
+extractChunks = R.pipe(
+  R.lPartial path.join, __dirname, '..'
+  fs.readFileSync
+  String
+  R.split /^/m
+  R.reduce (accum, line) ->
+    if accum.inExample and line isnt '```\n'
+      [init..., last] = accum.examples
+      inExample: true, examples: [init..., "#{last}#{line}"]
+    else if line is '```javascript\n'
+      inExample: true, examples: [accum.examples..., '']
+    else
+      inExample: false, examples: accum.examples
+  , inExample: false, examples: []
+  R.prop 'examples'
+  R.map R.pipe(
+    R.split /^/m
+    R.reduce (result, line) ->
+      match = /^[/][/] => (?:([A-Za-z]*Error): )?(.*)\n/.exec line
+      if match is null then "#{result}#{line}"
+      else result.replace /(.*)(?=\n$)/, (actual) ->
+        if match[1] then """
+          assert.throws(function() {
+            #{actual}
+          }, function(err) {
+            return err.name === '#{match[1]}' &&
+                   err.message === '#{match[2].replace /'/g, "\\'"}';
+          });
+        """
+        else """
+          assert.strictEqual(
+            #{actual},
+            #{match[2]}
+          );
+        """
+    , ''
+    R.concat 'format.extend(String.prototype);\n\n'
+  )
+)
+
+# blockquote :: String -> String
+blockquote = R.replace /^(?=[\s\S])/gm, '> '
+
+extractChunks 'README.md'
+.forEach (chunk) ->
+  try
+    vm.createScript "format.extend(String.prototype);\n\n#{chunk}"
+    .runInNewContext
+      assert: require 'assert'
+      format: format
+      require: R.always format
+      user: firstName: 'Jane', lastName: 'Smith', email: 'jsmith@example.com'
+  catch err
+    process.stderr.write "\n#{err}\n\n#{blockquote chunk}\n"
+    process.exit 1


### PR DESCRIPTION
This pull request is not yet ready to merge: the new API is not yet documented.

In short, prototype extension will become opt-in:

```javascript
var format = require('string-format');
format.extend(global);

format('Hello, {}!', 'Alice');  // => 'Hello, Alice!'
'Hello, {}!'.format('Alice');  // => 'Hello, Alice!'
```

Or simply:

```javascript
require('string-format').extend(global);
```

The other change is that transformers will no longer exist in a single namespace. Instead, a new `create` function takes a `transformers` map and returns a format function:

```javascript
var format = require('string-format').create({
  s: function(num) { return num === 1 ? '' : 's'; }
});
```

This means two unrelated packages which define their own transformers can be used together without conflict.

These two changes make it possible, for the first time, to responsibly add `string-format` as a dependency of a *library*. I look forward to doing so!

I'd love to hear your thoughts on these changes, @eush77.
