### PR TITLE
Fixing AMD Define

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@
   if (typeof module !== 'undefined') {
     module.exports = format;
   } else if (typeof define === 'function' && define.amd) {
-    define(format);
+    define(function() { return format; });
   } else {
     global.format = format;
   }


### PR DESCRIPTION
Require.js expects a callback function which will return the actual module, not the module itself.