### PR TITLE
Added dual licensing to get around WTFPL concerns.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@
             DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
                     Version 2, December 2004
 
- Copyright (c) 2012..2015 David Chambers <dc@davidchambers.me>
+ Copyright (c) 2012..2018 David Chambers <dc@davidchambers.me>
 
  Everyone is permitted to copy and distribute verbatim or modified
  copies of this license document, and changing it is allowed as long

--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,0 +1,24 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 David Chambers <dc@davidchambers.me>
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "homepage": "https://github.com/davidchambers/string-format",
   "bugs": "https://github.com/davidchambers/string-format/issues",
-  "license": "WTFPL",
+  "license": "(WTFPL OR MIT)",
   "repository": {
     "type": "git",
     "url": "git://github.com/davidchambers/string-format.git"


### PR DESCRIPTION
My company's lawyers are doing an audit of our software dependency licenses, and they're claiming WTFPL isn't a valid license or they have some sort of problem with it.

This PR adds dual licensing, I'm hoping this can get merged in so I don't have to swap out this lib with another one.