### PR TITLE
remove defaulting of null and undefined to empty string

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -59,6 +59,13 @@ suite('format', function() {
     );
   });
 
+  test('uses default string representations', function() {
+    eq(format('result: {}', null), 'result: null');
+    eq(format('result: {}', undefined), 'result: undefined');
+    eq(format('result: {}', [1, 2, 3]), 'result: 1,2,3');
+    eq(format('result: {}', {foo: 42}), 'result: [object Object]');
+  });
+
   test('treats "{{" and "}}" as "{" and "}"', function() {
     eq(format('{{ {}: "{}" }}', 'foo', 'bar'), '{ foo: "bar" }');
   });
@@ -73,6 +80,21 @@ suite('format', function() {
   test('accepts a shorthand for properties of the first positional argument', function() {
     var bobby = {first: 'Bobby', last: 'Fischer'};
     eq(format('{first} {last}', bobby), 'Bobby Fischer');
+  });
+
+  test('defaults to "" if lookup fails', function() {
+    eq(format('result: {foo.bar.baz}', null), 'result: ');
+    eq(format('result: {foo.bar.baz}', 'x'), 'result: ');
+    eq(format('result: {foo.bar.baz}', {}), 'result: ');
+    eq(format('result: {foo.bar.baz}', {foo: null}), 'result: ');
+    eq(format('result: {foo.bar.baz}', {foo: 'x'}), 'result: ');
+    eq(format('result: {foo.bar.baz}', {foo: {}}), 'result: ');
+    eq(format('result: {foo.bar.baz}', {foo: {bar: null}}), 'result: ');
+    eq(format('result: {foo.bar.baz}', {foo: {bar: 'x'}}), 'result: ');
+    eq(format('result: {foo.bar.baz}', {foo: {bar: {}}}), 'result: ');
+    eq(format('result: {foo.bar.baz}', {foo: {bar: {baz: null}}}), 'result: null');
+    eq(format('result: {foo.bar.baz}', {foo: {bar: {baz: 'x'}}}), 'result: x');
+    eq(format('result: {foo.bar.baz}', {foo: {bar: {baz: {}}}}), 'result: [object Object]');
   });
 
   test('invokes methods', function() {


### PR DESCRIPTION
Closes #35

Commit message:

> This commit changes the algorithm for nested lookups to avoid throwing. The new algorithm distinguishes failed lookups from successful lookups which happen to result in `null` or `undefined`:
>
> ```javascript
> > format('result: {foo.bar.baz}', null)
> 'result: '
>
> > format('result: {foo.bar.baz}', {foo: {bar: {baz: null}}})
> 'result: null'
> ```

/cc @RobPethick
